### PR TITLE
Add "unused" side to sides module

### DIFF
--- a/Libraries/Sides.lua
+++ b/Libraries/Sides.lua
@@ -13,6 +13,7 @@ return {
 	front = 3,
 	right = 4,
 	left = 5,
+	unknown = 6,
 	
 	down = 0,
 	up = 1,


### PR DESCRIPTION
Add "unused" side to sides module.
I would have the installer install ("Libraries/Sides.lua"), but I don't want to mess up the installer id system by going in blind.