### PR TITLE
fix remote write error

### DIFF
--- a/Libraries/Network.lua
+++ b/Libraries/Network.lua
@@ -542,7 +542,12 @@ local function newModemProxy(address)
 	end
 
 	proxy.write = function(handle, data)
-		local maxPacketSize = network.modemProxy.maxPacketSize() - network.modemPacketReserve
+		local maxPacketSize                                       -- В OC версий 1.11+ выпилили modem.maxPacketSize(), так-что чекаем, есть ли этот метод
+		if network.modemProxy.maxPacketSize then
+			maxPacketSize = network.modemProxy.maxPacketSize() - network.modemPacketReserve
+		else
+			maxPacketSize = 8192 - network.modemPacketReserve -- 8192 - стандартный размер пакета, судя по доке
+		end
 		repeat
 			if not request("write", false, handle, data:sub(1, maxPacketSize)) then
 				return false


### PR DESCRIPTION
Fixed error when trying to write file on remote machine on minecraft versions 1.11+. OC devs removed modem.maxPacketSize() method, so, we need to check if it present.
![image](https://user-images.githubusercontent.com/53402621/123871946-0977a300-d93d-11eb-8ccc-00ee9b353ccb.png)
