### PR TITLE
Use HTTPS for pastebin upload

### DIFF
--- a/Libraries/System.lua
+++ b/Libraries/System.lua
@@ -347,7 +347,7 @@ local function uploadToPastebin(path)
 				workspace:draw()
 
 				local internet = require("Internet")
-				result, reason = internet.request("http://pastebin.com/api/api_post.php", internet.serialize({
+				result, reason = internet.request("https://pastebin.com/api/api_post.php", internet.serialize({
 					api_option = "paste",
 					api_dev_key = "fd92bd40a84c127eeb6804b146793c97",
 					api_paste_expire_date = "N",


### PR DESCRIPTION
Pastebin apparently requires HTTPS now, using HTTP just fails.