### PR TITLE
Fix materials.newDebugTexture and simplify

### DIFF
--- a/Libraries/OpenComputersGL/Materials.lua
+++ b/Libraries/OpenComputersGL/Materials.lua
@@ -11,22 +11,12 @@ materials.types = {
 
 function materials.newDebugTexture(width, height, h)
 	local texture = {width = width, height = height}
-		
-	local bStep = 1 / height
-	local sStep = 1 / width
-
-	local s, b = 0, 0
-	local blackSquare = false
+	
 	for y = 1, height do
 		texture[y] = {}
 		for x = 1, width do
-			texture[y][x] = blackSquare == true and 0x0 or color.HSBToInteger(h, s, b)
-			blackSquare = not blackSquare
-			b = b + bStep
+			texture[y][x] = not (x+y)%2 and 0x0 or color.HSBToInteger(h, y/height, x/width)
 		end
-		b = 0
-		s = s + sStep
-		blackSquare = not blackSquare
 	end
 	return texture
 end


### PR DESCRIPTION
I was testing a copy of this in Python, and noticed that bStep and sStep appear to be swapped, as bStep changed b up by 1/height, but the loop is by width, leading b to exceed 1 if the height is smaller than width. This is only apparent if the width and height of the new debug texture is not the same. And then I also noticed that the whole "invert blackSquare in two places" part could be simplified to if x + y is an odd number for each pixel in the texture. I don't claim to know the specifics of how to make lua faster, and this may be slower, so whatever is better.