### PR TITLE
Basically only imortant from #408

### DIFF
--- a/Libraries/OpenComputersGL/Materials.lua
+++ b/Libraries/OpenComputersGL/Materials.lua
@@ -12,8 +12,8 @@ materials.types = {
 function materials.newDebugTexture(width, height, h)
 	local texture = {width = width, height = height}
 		
-	local bStep = 1 / height
-	local sStep = 1 / width
+	local bStep = 1 / width
+	local sStep = 1 / height
 
 	local s, b = 0, 0
 	local blackSquare = false


### PR DESCRIPTION
Basically only the important part of pull #408 because I am not lua pro.
Leave blackSqare and step counters alone, but make it be able to handle textures where width and height are not the same so no more invalid color error.
For example, with original code, materials.newDebugTexture(8, 16, 40) has odd color because when it gets to pixel (1, 9), color value is (15, 9, -2) in RGB. After color.RGBToInteger inside color.HSBToInteger, integer value for color would be -2. The reason it's not apparent is likely from optimization of colors from palette, turning -2 into 65535 or (0, 255, 255), instead of an invalid color.
This has the effect of screwing up the colors for the image
If steps are swapped as this proposes, this issue is fixed and the colors wouldn't go crazy.

materials.newDebugTexture(8, 16, 40):

Original:
![original](https://user-images.githubusercontent.com/52022020/148649553-54d0b2fa-ca63-4579-a3c8-1f3235a8f053.png)

Fixed, but using color.optimize
![fixed_optimized](https://user-images.githubusercontent.com/52022020/148649550-34607117-d6ae-4fe1-b781-57833c63223a.png)

Fixed unoptimized
![fixed_unoptimized](https://user-images.githubusercontent.com/52022020/148649552-62000655-8611-43b9-a053-6b5cac84a030.png)

