### PR TITLE
Что я к этим ярлыкам то прикопался...

### DIFF
--- a/Libraries/System.lua
+++ b/Libraries/System.lua
@@ -593,7 +593,7 @@ local function moveSelectedIconsToTrash(selectedIcons)
 	for i = 1, #selectedIcons do
 		icon = selectedIcons[i]
 
-		if filesystem.path(icon.path) == paths.user.trash then
+		if filesystem.path(icon.path) == paths.user.trash or icon.isShortcut then
 			filesystem.remove(icon.path)
 		else
 			local name = filesystem.name(icon.path)

--- a/Libraries/System.lua
+++ b/Libraries/System.lua
@@ -587,31 +587,35 @@ local function iconDeselectAndSelect(icon)
 	workspace:draw()
 end
 
+local function moveToTrash(path)
+	local ext = filesystem.extension(path)
+	local name = filesystem.name(path)
+	local dir = filesystem.path(path)
+	if dir == paths.user.trash or ext == ".lnk" then
+			filesystem.remove(path)
+	else
+		local name = filesystem.name(path)
+		local clearName = filesystem.hideExtension(name)
+		local newPath = paths.user.trash .. name
+		local repeats = 1
+
+		while filesystem.exists(newPath) do
+			newPath, repeats = paths.user.trash .. clearName .. string.rep("-copy", repeats) .. (ext or ""), repeats + 1
+		end
+
+		filesystem.rename(path, newPath)
+	end
+	computer.pushSignal("system", "updateFileList")
+end
+
 local function moveSelectedIconsToTrash(selectedIcons)
 	local icon
 
 	for i = 1, #selectedIcons do
 		icon = selectedIcons[i]
-
-		if filesystem.path(icon.path) == paths.user.trash or icon.isShortcut then
-			filesystem.remove(icon.path)
-		else
-			local name = filesystem.name(icon.path)
-			local clearName = filesystem.hideExtension(name)
-			local newPath = paths.user.trash .. name
-			local repeats = 1
-
-			while filesystem.exists(newPath) do
-				newPath, repeats = paths.user.trash .. clearName .. string.rep("-copy", repeats) .. (icon.extension or ""), repeats + 1
-			end
-
-			filesystem.rename(icon.path, newPath)
-		end
-		
+		moveToTrash(icon.path)
 		icon.selected = false
 	end
-
-	computer.pushSignal("system", "updateFileList")
 end
 
 local function iconOnRightClick(selectedIcons, icon, e1, e2, e3, e4)
@@ -872,6 +876,13 @@ local function iconOnRightClick(selectedIcons, icon, e1, e2, e3, e4)
 
 	contextMenu:addItem(localization.delete).onTouch = function()
 		moveSelectedIconsToTrash(selectedIcons)
+	end
+
+	if icon.isShortcut then
+		contextMenu:addItem(localization.deleteWithSource).onTouch = function()
+			moveToTrash(icon.shortcutPath)
+			moveToTrash(icon.path)
+		end
 	end
 
 	contextMenu:addSeparator()

--- a/Localizations/Bulgarian.lang
+++ b/Localizations/Bulgarian.lang
@@ -74,6 +74,7 @@
 	rename = "Преименуване",
 	editShortcut = "Редактиране на пряк път",
 	createShortcut = "Създаване на пряк път",
+	deleteWithSource = "Изтриване с източник",
 	addToDock = "Добавяне в дока",
 	removeFromDock = "Премахване от дока",
 	moveRight = "Премести вдясно",

--- a/Localizations/Chinese.lang
+++ b/Localizations/Chinese.lang
@@ -75,6 +75,7 @@
 	rename = "重命名",
 	editShortcut = "编辑快捷方式",
 	createShortcut = "创建快捷方式",
+	deleteWithSource = "刪除源",
 	addToDock = "添加到Dock",
 	removeFromDock = "从Dock中删除",
 	moveRight = "向右移动",

--- a/Localizations/English.lang
+++ b/Localizations/English.lang
@@ -75,6 +75,7 @@
 	rename = "Rename",
 	editShortcut = "Edit shortcut",
 	createShortcut = "Create shortcut",
+	deleteWithSource = "Delete with source",
 	addToDock = "Add to Dock",
 	removeFromDock = "Remove from Dock",
 	moveRight = "Move right",

--- a/Localizations/French.lang
+++ b/Localizations/French.lang
@@ -75,6 +75,7 @@
 	rename = "Renommer",
 	editShortcut = "Modifier le raccourci",
 	createShortcut = "Créer un raccourci",
+	deleteWithSource = "Supprimer avec la source",
 	addToDock = "Ajouter à la barre des tâches",
 	removeFromDock = "Retirer de la barre des tâches",
 	moveRight = "Déplacer vers la droite",

--- a/Localizations/German.lang
+++ b/Localizations/German.lang
@@ -75,6 +75,7 @@
 	rename = "Umbenennen",
 	editShortcut = "Verknüpfung bearbeiten",
 	createShortcut = "Verknüpfung erstellen",
+	deleteWithSource = "Mit Quelle löschen",
 	addToDock = "Zum Dock hinzufügen",
 	removeFromDock = "Aus Dock entfernen",
 	moveRight = "Nach rechts bewegen",

--- a/Localizations/Italian.lang
+++ b/Localizations/Italian.lang
@@ -75,6 +75,7 @@
 	rename = "Rinomina",
 	editShortcut = "Modifica scorciatoia",
 	createShortcut = "Crea scorciatoia",
+	deleteWithSource = "Elimina con fonte",
 	addToDock = "Aggiungi alla bacheca",
 	removeFromDock = "Rimuovi Dalla bacheca",
 	moveRight = "Sposta a destra",

--- a/Localizations/Japanese.lang
+++ b/Localizations/Japanese.lang
@@ -75,6 +75,7 @@
 	rename = "名前を変更　",
 	editShortcut = "ショートカットを編集",
 	createShortcut = "ショートカットを作成",
+	deleteWithSource = "ソースで削除",
 	addToDock = "Dockに追加",
 	removeFromDock = "Dockから削除",
 	moveRight = "右に移動",

--- a/Localizations/Russian.lang
+++ b/Localizations/Russian.lang
@@ -75,6 +75,7 @@
 	rename = "Переименовать",
 	editShortcut = "Редактировать ярлык",
 	createShortcut = "Создать ярлык",
+	deleteWithSource = "Удалить с источником",
 	addToDock = "Добавить в Dock",
 	removeFromDock = "Удалить из Dock",
 	moveRight = "Передвинуть правее",

--- a/Localizations/Slovak.lang
+++ b/Localizations/Slovak.lang
@@ -75,6 +75,7 @@
 	rename = "Premenovať",
 	editShortcut = "Upraviť odkaz",
 	createShortcut = "Vytvoriť odkaz",
+	deleteWithSource = "Odstrániť so zdrojom",
 	addToDock = "Pridať do lišty",
 	removeFromDock = "Odstrániť z lišty",
 	moveRight = "Posunúť doprava",

--- a/Localizations/Ukrainian.lang
+++ b/Localizations/Ukrainian.lang
@@ -75,6 +75,7 @@
 	rename = "Перейменувати",
 	editShortcut = "Змінити ярлик",
 	createShortcut = "Створити ярлик",
+	deleteWithSource = "Видалити з джерелом",
 	addToDock = "Додати в док",
 	removeFromDock = "Видалити з док",
 	moveRight = "Перемістити вправо",


### PR DESCRIPTION
Предлагаю свои две фичи:
1. Ярлыки при удалении минуют корзину и отправляются сразу в небытие (ну а нафиг они нужны в корзине)
2. Есть новое поле в контекстном меню только для ярлыков - "Удалить с источником" (приложуха или что там отправляется в корзину, а сам ярлык, как следует из п.1, улетает на луну)

А сия великолепная гифка полностью демонстрирует новый функционал:
![](https://gyazo.com/4b8a6e885a7082557abe8c067d847509.gif)

P.S. изменил `moveSelectedIconsToTrash` и вынес оттуда кусок в новую `moveToTrash`, типа можно через `moveToTrash(path)` в корзину слать файлы