### PR TITLE
Add new `hideApplicationPreviews` key

### DIFF
--- a/Applications/App Market.app/Localizations/Arabic.lang
+++ b/Applications/App Market.app/Localizations/Arabic.lang
@@ -14,23 +14,23 @@
 	yourText = "أنت:",
 	hereBeYourDialogs = "هنا ستكون محادثاتك",
 	hideApplicationIcons = "إخفاء رموز التطبيق",
-	
 	categoryOverview = "ملخص",
+	
 	categoryApplications = "التطبيقات",
 	categoryLibraries = "مكتبات",
 	categoryScripts = "نصوص",
 	categoryUpdates = "التحديثات",
 	categoryWallpapers = "خلفيات",
-	
 	statisticsNewUser = "مستخدم جديد",
+	
 	statisticsMostPopularUser = "أكثر نشاطا",
 	statisticsUsersCount = "عدد المستخدمين",
 	statisticsPublicationsCount = "عدد المنشورات",
 	statisticsReviewsCount = "عدد التعليقات",
 	statisticsPopularPublication = "(منشور شعبي)",
 	statisticsMessagesCount = "عدد الرسائل",
-	
 	whatsNew = "ما هو الجديد",
+	
 	whatsNewInVersion = "ما الجديد في الإصدار",
 	areYouSure = "هل أنت متأكد من أنك تريد حذف المنشور؟",
 	createShortcut = "إنشاء اختصار سطح المكتب",
@@ -54,8 +54,8 @@
 	relativePath = "مسار نسبي",
 	localizationDependency = "ملف الترجمة",
 	login = "يسجل دخول",
-	
 	profile = "حساب تعريفي",
+	
 	nickname = "اسم الشهرة",
 	password = "كلمه السر",
 	nicknameOrEmail = "البريد الإلكتروني أو الاسم المستعار",
@@ -75,8 +75,8 @@
 	createAccount = "إنشاء حساب",
 	registrationSuccessfull = "تحقق من البريد الإلكتروني ومجلد البريد العشوائي للتحقق من حسابك",
 	search = "بحث",
-	
 	byPopularity = "حسب الشعبية",
+	
 	byRating = "حسب التصنيف",
 	byDate = "حسب التاريخ",
 	byName = "بالاسم",
@@ -90,8 +90,8 @@
 	updateAll = "تحديث الجميع",
 	noUpdates = "ليس لديك تحديثات",
 	changeReview = "تغيير الاستعراض",
-	
 	developer = "مطور",
+	
 	version = "الإصدار",
 	license = "رخصة",
 	category = "فئة",
@@ -111,5 +111,6 @@
 	usersLoveReview = "وجد المستخدمون هذه المراجعة مفيدة",
 	thanksForVote = "شكرا لرأيك.",
 	previewDepencency = "صورة المعاينة",
-	uniqueDownloads = "تنزيلات فريدة"
+	uniqueDownloads = "تنزيلات فريدة",
+	hideApplicationPreviews = "إخفاء معاينات التطبيق"
 }

--- a/Applications/App Market.app/Localizations/Belarusian.lang
+++ b/Applications/App Market.app/Localizations/Belarusian.lang
@@ -14,23 +14,23 @@
 	yourText = "Вы:",
 	hereBeYourDialogs = "Тут будуць вашы размовы",
 	hideApplicationIcons = "Схаваць значкі прыкладанняў",
-	
 	categoryOverview = "Агляд",
+	
 	categoryApplications = "Прыкладанні",
 	categoryLibraries = "Бібліятэкі",
 	categoryScripts = "Сцэнарыі",
 	categoryUpdates = "Абнаўленні",
 	categoryWallpapers = "Шпалеры",
-	
 	statisticsNewUser = "Новы карыстальнік",
+	
 	statisticsMostPopularUser = "Найбольш актыўныя",
 	statisticsUsersCount = "Карыстальнікі падлічваюцца",
 	statisticsPublicationsCount = "Падлічваюцца публікацыі",
 	statisticsReviewsCount = "Водгукі залічваюцца",
 	statisticsPopularPublication = "(папулярнае выданне)",
 	statisticsMessagesCount = "Паведамленні лічацца",
-	
 	whatsNew = "Што новага",
+	
 	whatsNewInVersion = "Што новага ў версіі",
 	areYouSure = "Вы ўпэўненыя, што хочаце выдаліць публікацыю?",
 	createShortcut = "Стварыць ярлык на працоўным стале",
@@ -54,8 +54,8 @@
 	relativePath = "Адносны шлях",
 	localizationDependency = "Файл лакалізацыі",
 	login = "Увайсці",
-	
 	profile = "Профіль",
+	
 	nickname = "Мянушка",
 	password = "Пароль",
 	nicknameOrEmail = "Электронная пошта або нік",
@@ -75,8 +75,8 @@
 	createAccount = "Стварыць уліковы запіс",
 	registrationSuccessfull = "Праверце электронную пошту і папку са спамам, каб пацвердзіць свой уліковы запіс",
 	search = "Пошук",
-	
 	byPopularity = "Па папулярнасці",
+	
 	byRating = "Па рэйтынгу",
 	byDate = "Па даце",
 	byName = "Па імені",
@@ -90,8 +90,8 @@
 	updateAll = "Абнавіць усе",
 	noUpdates = "У вас няма абнаўленняў",
 	changeReview = "Змяніць агляд",
-	
 	developer = "Распрацоўшчык",
+	
 	version = "Версія",
 	license = "Ліцэнзія",
 	category = "Катэгорыя",
@@ -111,5 +111,6 @@
 	usersLoveReview = "карыстальнікі палічылі гэты агляд карысным",
 	thanksForVote = "Дзякуй за ваша меркаванне.",
 	previewDepencency = "Папярэдні прагляд выявы",
-	uniqueDownloads = "Унікальныя загрузкі"
+	uniqueDownloads = "Унікальныя загрузкі",
+	hideApplicationPreviews = "Схаваць папярэдні прагляд прыкладанняў"
 }

--- a/Applications/App Market.app/Localizations/Bengali.lang
+++ b/Applications/App Market.app/Localizations/Bengali.lang
@@ -14,23 +14,23 @@
 	yourText = "আপনি:",
 	hereBeYourDialogs = "এখানে আপনার কথোপকথন হবে",
 	hideApplicationIcons = "অ্যাপ্লিকেশন আইকন লুকান",
-	
 	categoryOverview = "ওভারভিউ",
+	
 	categoryApplications = "অ্যাপ্লিকেশন",
 	categoryLibraries = "লাইব্রেরি",
 	categoryScripts = "স্ক্রিপ্ট",
 	categoryUpdates = "আপডেট",
 	categoryWallpapers = "ওয়ালপেপার",
-	
 	statisticsNewUser = "নতুন ব্যবহারকারী",
+	
 	statisticsMostPopularUser = "সবচেয়ে সক্রিয়",
 	statisticsUsersCount = "ব্যবহারকারী গণনা",
 	statisticsPublicationsCount = "প্রকাশনা গণনা",
 	statisticsReviewsCount = "রিভিউ গণনা",
 	statisticsPopularPublication = "(জনপ্রিয় প্রকাশনা)",
 	statisticsMessagesCount = "বার্তা গণনা",
-	
 	whatsNew = "নতুন কি",
+	
 	whatsNewInVersion = "সংস্করণে নতুন কি আছে",
 	areYouSure = "আপনি কি নিশ্চিত প্রকাশনা মুছে দিতে চান?",
 	createShortcut = "ডেস্কটপ শর্টকাট তৈরি কর",
@@ -54,8 +54,8 @@
 	relativePath = "আপেক্ষিক পাথ",
 	localizationDependency = "স্থানীয়করণ ফাইল",
 	login = "প্রবেশ করুন",
-	
 	profile = "প্রোফাইল",
+	
 	nickname = "ডাকনাম",
 	password = "পাসওয়ার্ড",
 	nicknameOrEmail = "ই-মেইল বা ডাকনাম",
@@ -75,8 +75,8 @@
 	createAccount = "হিসাব তৈরি কর",
 	registrationSuccessfull = "আপনার অ্যাকাউন্ট যাচাই করতে আপনার ই-মেইল এবং স্প্যাম ফোল্ডার চেক করুন",
 	search = "অনুসন্ধান করুন",
-	
 	byPopularity = "জনপ্রিয়তা দ্বারা",
+	
 	byRating = "রেটিং দ্বারা",
 	byDate = "তারিখ অনুসারে",
 	byName = "নামে",
@@ -90,8 +90,8 @@
 	updateAll = "সব আপডেট",
 	noUpdates = "আপনার কোন আপডেট নেই",
 	changeReview = "পর্যালোচনা পরিবর্তন করুন",
-	
 	developer = "বিকাশকারী",
+	
 	version = "সংস্করণ",
 	license = "লাইসেন্স",
 	category = "শ্রেণী",
@@ -111,5 +111,6 @@
 	usersLoveReview = "ব্যবহারকারীরা এই পর্যালোচনা সহায়ক বলে মনে করেছেন",
 	thanksForVote = "আপনার মতামতের জন্য ধন্যবাদ.",
 	previewDepencency = "পূর্বরূপ চিত্র",
-	uniqueDownloads = "অনন্য ডাউনলোড"
+	uniqueDownloads = "অনন্য ডাউনলোড",
+	hideApplicationPreviews = "অ্যাপ্লিকেশন পূর্বরূপ লুকান"
 }

--- a/Applications/App Market.app/Localizations/Bulgarian.lang
+++ b/Applications/App Market.app/Localizations/Bulgarian.lang
@@ -14,23 +14,23 @@
 	yourText = "Вие:",
 	hereBeYourDialogs = "Тук ще бъдат вашите разговори",
 	hideApplicationIcons = "Скриване на иконите на приложенията",
-	
 	categoryOverview = "Общ преглед",
+	
 	categoryApplications = "Приложения",
 	categoryLibraries = "библиотеки",
 	categoryScripts = "Скриптове",
 	categoryUpdates = "Актуализации",
 	categoryWallpapers = "Тапети",
-	
 	statisticsNewUser = "Нов потребител",
+	
 	statisticsMostPopularUser = "Най-активен",
 	statisticsUsersCount = "Потребителите се броят",
 	statisticsPublicationsCount = "Публикациите се броят",
 	statisticsReviewsCount = "Отзивите се броят",
 	statisticsPopularPublication = "(популярна публикация)",
 	statisticsMessagesCount = "Съобщенията се броят",
-	
 	whatsNew = "Какво ново",
+	
 	whatsNewInVersion = "Какво ново във версията",
 	areYouSure = "Сигурни ли сте, че искате да изтриете публикацията?",
 	createShortcut = "Създайте пряк път на работния плот",
@@ -54,8 +54,8 @@
 	relativePath = "Относителен път",
 	localizationDependency = "Файл за локализация",
 	login = "Влизане",
-	
 	profile = "Профил",
+	
 	nickname = "Псевдоним",
 	password = "парола",
 	nicknameOrEmail = "Имейл или псевдоним",
@@ -75,8 +75,8 @@
 	createAccount = "Създай акаунт",
 	registrationSuccessfull = "Проверете електронната си поща и папката за спам, за да потвърдите акаунта си",
 	search = "Търсене",
-	
 	byPopularity = "По популярност",
+	
 	byRating = "По рейтинг",
 	byDate = "По дата",
 	byName = "По име",
@@ -90,8 +90,8 @@
 	updateAll = "Актуализирай всички",
 	noUpdates = "Нямате актуализации",
 	changeReview = "Промяна на прегледа",
-	
 	developer = "Разработчик",
+	
 	version = "Версия",
 	license = "Разрешително",
 	category = "Категория",
@@ -111,5 +111,6 @@
 	usersLoveReview = "потребителите намират този преглед за полезен",
 	thanksForVote = "Благодаря за вашето мнение.",
 	previewDepencency = "Визуализация на изображението",
-	uniqueDownloads = "Уникални изтегляния"
+	uniqueDownloads = "Уникални изтегляния",
+	hideApplicationPreviews = "Скриване на визуализации на приложения"
 }

--- a/Applications/App Market.app/Localizations/Chinese.lang
+++ b/Applications/App Market.app/Localizations/Chinese.lang
@@ -14,23 +14,23 @@
 	yourText = "你:",
 	hereBeYourDialogs = "这是你们的谈话内容",
 	hideApplicationIcons = "隱藏應用程序圖標",
-	
 	categoryOverview = "预览",
+	
 	categoryApplications = "软件",
 	categoryLibraries = "库",
 	categoryScripts = "脚本",
 	categoryUpdates = "更新",
 	categoryWallpapers = "壁紙",
-	
 	statisticsNewUser = "新用户",
+	
 	statisticsMostPopularUser = "最积极",
 	statisticsUsersCount = "用户数量",
 	statisticsPublicationsCount = "软件数量",
 	statisticsReviewsCount = "评论数量",
 	statisticsPopularPublication = "最受欢迎的软件",
 	statisticsMessagesCount = "信息数",
-	
 	whatsNew = "什麼是新的",
+	
 	whatsNewInVersion = "版本的新功能",
 	areYouSure = "您確定要刪除出版物嗎？",
 	createShortcut = "創建桌面快捷方式",
@@ -54,8 +54,8 @@
 	relativePath = "相對路徑",
 	localizationDependency = "本地化文件",
 	login = "登录",
-	
 	profile = "账户",
+	
 	nickname = "昵称",
 	password = "密码",
 	nicknameOrEmail = "邮箱或昵称",
@@ -75,8 +75,8 @@
 	createAccount = "注册",
 	registrationSuccessfull = "请去检查邮箱，并点击发来的链接",
 	search = "搜索",
-	
 	byPopularity = "最受欢迎",
+	
 	byRating = "最高评分",
 	byDate = "创建日期",
 	byName = "通过名称",
@@ -90,8 +90,8 @@
 	updateAll = "更新所有",
 	noUpdates = "已经是最新版",
 	changeReview = "修改评论",
-	
 	developer = "开发者",
+	
 	version = "版本",
 	license = "协议",
 	category = "类型",
@@ -111,5 +111,6 @@
 	usersLoveReview = "人认为这条评论有用",
 	thanksForVote = "感谢你的观点。",
 	previewDepencency = "預覽影像",
-	uniqueDownloads = "獨特的下載量"
+	uniqueDownloads = "獨特的下載量",
+	hideApplicationPreviews = "隱藏應用程式預覽"
 }

--- a/Applications/App Market.app/Localizations/Dutch.lang
+++ b/Applications/App Market.app/Localizations/Dutch.lang
@@ -14,23 +14,23 @@
 	yourText = "Jij:",
 	hereBeYourDialogs = "Hier zullen uw gesprekken zijn",
 	hideApplicationIcons = "Applicatiepictogrammen verbergen",
-	
 	categoryOverview = "Overzicht",
+	
 	categoryApplications = "Applicaties",
 	categoryLibraries = "Bibliotheken",
 	categoryScripts = "Scripts",
 	categoryUpdates = "Updates",
 	categoryWallpapers = "Achtergronden",
-	
 	statisticsNewUser = "Nieuwe gebruiker",
+	
 	statisticsMostPopularUser = "Meest actief",
 	statisticsUsersCount = "Aantal gebruikers",
 	statisticsPublicationsCount = "Aantal Publicaties",
 	statisticsReviewsCount = "Aantal beoordelingen",
 	statisticsPopularPublication = "(populaire publicatie)",
 	statisticsMessagesCount = "Aantal berichten",
-	
 	whatsNew = "Wat is er nieuw",
+	
 	whatsNewInVersion = "Wat is er nieuw in de versie",
 	areYouSure = "Weet je zeker dat je de publicatie wilt verwijderen?",
 	createShortcut = "Maak snelkoppeling op het bureaublad",
@@ -54,8 +54,8 @@
 	relativePath = "Relatief pad",
 	localizationDependency = "Lokalisatiebestand",
 	login = "Log in",
-	
 	profile = "Profiel",
+	
 	nickname = "naam",
 	password = "Wachtwoord",
 	nicknameOrEmail = "E-Mail of naam",
@@ -75,8 +75,8 @@
 	createAccount = "Maak account",
 	registrationSuccessfull = "Bevestig uw account via de link in de e-mail (controleer uw spam map)",
 	search = "Zoeken",
-	
 	byPopularity = "Op populariteit",
+	
 	byRating = "Op beoordeling",
 	byDate = "Op datum",
 	byName = "Op naam",
@@ -90,8 +90,8 @@
 	updateAll = "Update alles",
 	noUpdates = "Je hebt momenteel geen updates",
 	changeReview = "Verander beoordeling",
-	
 	developer = "Ontwikkelaar",
+	
 	version = "Versie",
 	license = "Licentie",
 	category = "Categorie",
@@ -111,5 +111,6 @@
 	usersLoveReview = "Gebruikers vonden deze beoordeling behulpzaam",
 	thanksForVote = "Bedankt voor uw mening.",
 	previewDepencency = "Voorbeeldafbeelding",
-	uniqueDownloads = "Unieke downloads"
+	uniqueDownloads = "Unieke downloads",
+	hideApplicationPreviews = "Applicatievoorbeelden verbergen"
 }

--- a/Applications/App Market.app/Localizations/Finnish.lang
+++ b/Applications/App Market.app/Localizations/Finnish.lang
@@ -14,23 +14,23 @@
 	yourText = "Sinä:",
 	hereBeYourDialogs = "Tässä ovat keskustelusi",
 	hideApplicationIcons = "Piilota sovelluskuvakkeet",
-	
 	categoryOverview = "Yleiskatsaus",
+	
 	categoryApplications = "Sovellukset",
 	categoryLibraries = "Kirjastot",
 	categoryScripts = "Käsikirjoitukset",
 	categoryUpdates = "Päivitykset",
 	categoryWallpapers = "Taustakuvat",
-	
 	statisticsNewUser = "Uusi käyttäjä",
+	
 	statisticsMostPopularUser = "Aktiivisin",
 	statisticsUsersCount = "Käyttäjiä lasketaan",
 	statisticsPublicationsCount = "Julkaisut lasketaan",
 	statisticsReviewsCount = "Arvostelut lasketaan",
 	statisticsPopularPublication = "(suosittu julkaisu)",
 	statisticsMessagesCount = "Viestit lasketaan",
-	
 	whatsNew = "Mikä on uutta",
+	
 	whatsNewInVersion = "Mitä uutta versiossa",
 	areYouSure = "Haluatko varmasti poistaa julkaisun?",
 	createShortcut = "Luo pikakuvake työpöydälle",
@@ -54,8 +54,8 @@
 	relativePath = "Suhteellinen polku",
 	localizationDependency = "Lokalisointitiedosto",
 	login = "Kirjaudu sisään",
-	
 	profile = "Profiili",
+	
 	nickname = "Nimimerkki",
 	password = "Salasana",
 	nicknameOrEmail = "Sähköposti tai lempinimi",
@@ -75,8 +75,8 @@
 	createAccount = "Luo tili",
 	registrationSuccessfull = "Tarkista sähköpostisi ja roskapostikansiosi vahvistaaksesi tilisi",
 	search = "Hae",
-	
 	byPopularity = "Suosion mukaan",
+	
 	byRating = "Luokituksen mukaan",
 	byDate = "Päivämäärän mukaan",
 	byName = "Nimeltä",
@@ -90,8 +90,8 @@
 	updateAll = "Päivitä kaikki",
 	noUpdates = "Sinulla ei ole päivityksiä",
 	changeReview = "Muuta arvostelua",
-	
 	developer = "Kehittäjä",
+	
 	version = "Versio",
 	license = "Lisenssi",
 	category = "Kategoria",
@@ -111,5 +111,6 @@
 	usersLoveReview = "käyttäjät pitivät tätä arvostelua hyödyllisenä",
 	thanksForVote = "Kiitos mielipiteestäsi.",
 	previewDepencency = "Esikatselukuva",
-	uniqueDownloads = "Ainutlaatuiset lataukset"
+	uniqueDownloads = "Ainutlaatuiset lataukset",
+	hideApplicationPreviews = "Piilota sovellusten esikatselut"
 }

--- a/Applications/App Market.app/Localizations/French.lang
+++ b/Applications/App Market.app/Localizations/French.lang
@@ -14,23 +14,23 @@
 	yourText = "Vous :",
 	hereBeYourDialogs = "Voici vos conversations",
 	hideApplicationIcons = "Masquer les icônes des applications",
-	
 	categoryOverview = "Aperçu",
+	
 	categoryApplications = "Applications",
 	categoryLibraries = "API",
 	categoryScripts = "Scénarios",
 	categoryUpdates = "Mises à jour",
 	categoryWallpapers = "Fonds d'écran",
-	
 	statisticsNewUser = "Nouvel utilisateur",
+	
 	statisticsMostPopularUser = "Plus actif",
 	statisticsUsersCount = "Nombre d'utilisateurs",
 	statisticsPublicationsCount = "Nombre de publications",
 	statisticsReviewsCount = "Nombre de commentaires",
 	statisticsPopularPublication = "(publication populaire)",
 	statisticsMessagesCount = "Nombre de messages",
-	
 	whatsNew = "Quoi de neuf",
+	
 	whatsNewInVersion = "Quoi de neuf dans la version",
 	areYouSure = "Êtes-vous sûr de vouloir supprimer la publication ?",
 	createShortcut = "Créer un raccourci sur le bureau",
@@ -54,8 +54,8 @@
 	relativePath = "Chemin relatif",
 	localizationDependency = "Fichier de localisation",
 	login = "S'identifier",
-	
 	profile = "Profil",
+	
 	nickname = "Pseudo",
 	password = "Mot de passe",
 	nicknameOrEmail = "E-Mail ou pseudo",
@@ -75,8 +75,8 @@
 	createAccount = "Créer un compte",
 	registrationSuccessfull = "Vérifiez votre boite mail et le dossier de courrier indésirable pour valider votre compte",
 	search = "Rechercher",
-	
 	byPopularity = "Par popularité",
+	
 	byRating = "Par notation",
 	byDate = "Par date",
 	byName = "Par nom",
@@ -90,8 +90,8 @@
 	updateAll = "Tout mettre à jour",
 	noUpdates = "Aucune mises à jour n'est disponible",
 	changeReview = "Changer de critique",
-	
 	developer = "Développeur",
+	
 	version = "Version",
 	license = "Licence",
 	category = "Catégorie",
@@ -111,5 +111,6 @@
 	usersLoveReview = "utilisateurs ont trouvé cet avis utile",
 	thanksForVote = "Merci pour votre avis.",
 	previewDepencency = "Aperçu de l'image",
-	uniqueDownloads = "Téléchargements uniques"
+	uniqueDownloads = "Téléchargements uniques",
+	hideApplicationPreviews = "Masquer les aperçus des applications"
 }

--- a/Applications/App Market.app/Localizations/German.lang
+++ b/Applications/App Market.app/Localizations/German.lang
@@ -14,23 +14,23 @@
 	yourText = "Sie:",
 	hereBeYourDialogs = "Hier werden Ihre Gespräche",
 	hideApplicationIcons = "Anwendungssymbole ausblenden",
-	
 	categoryOverview = "Überblick",
+	
 	categoryApplications = "Anwendungen",
 	categoryLibraries = "Bibliothek",
 	categoryScripts = "Skript",
 	categoryUpdates = "Aktualisierung",
 	categoryWallpapers = "Hintergrundbilder",
-	
 	statisticsNewUser = "Neuer Benutzer",
+	
 	statisticsMostPopularUser = "Aktivsten",
 	statisticsUsersCount = "Anzahl der Benutzer",
 	statisticsPublicationsCount = "Publikationen zählen",
 	statisticsReviewsCount = "Bewertungen zählen",
 	statisticsPopularPublication = "(beliebte Publikation)",
 	statisticsMessagesCount = "Nachrichten zählen",
-	
 	whatsNew = "Was gibt ' s neues",
+	
 	whatsNewInVersion = "Was in der version neu ist",
 	areYouSure = "Möchten Sie die Veröffentlichung wirklich löschen?",
 	createShortcut = "Desktop-Verknüpfung erstellen",
@@ -54,8 +54,8 @@
 	relativePath = "Relativer Pfad",
 	localizationDependency = "Lokalisierungsdatei",
 	login = "Anmelden",
-	
 	profile = "Profil",
+	
 	nickname = "Spitzname",
 	password = "Passwort",
 	nicknameOrEmail = "E-Mail oder Spitzname",
@@ -75,8 +75,8 @@
 	createAccount = "Konto erstellen",
 	registrationSuccessfull = "Überprüfen Sie Ihren E-mail-und spam-Ordner, um Ihr Konto zu überprüfen",
 	search = "Suche",
-	
 	byPopularity = "Nach Beliebtheit",
+	
 	byRating = "Nach Bewertung",
 	byDate = "Nach Datum",
 	byName = "Namentlich",
@@ -90,8 +90,8 @@
 	updateAll = "Alle aktualisieren",
 	noUpdates = "Sie haben keine updates",
 	changeReview = "Überprüfung ändern",
-	
 	developer = "Entwickler",
+	
 	version = "Ausführung",
 	license = "Lizenz",
 	category = "Zimmerkategorie",
@@ -111,5 +111,6 @@
 	usersLoveReview = "Benutzer fanden diese Bewertung hilfreich",
 	thanksForVote = "Vielen Dank für Ihre Meinung.",
 	previewDepencency = "Vorschaubild",
-	uniqueDownloads = "Einzigartige Downloads"
+	uniqueDownloads = "Einzigartige Downloads",
+	hideApplicationPreviews = "Anwendungsvorschauen ausblenden"
 }

--- a/Applications/App Market.app/Localizations/Hindi.lang
+++ b/Applications/App Market.app/Localizations/Hindi.lang
@@ -14,23 +14,23 @@
 	yourText = "आप:",
 	hereBeYourDialogs = "यहां आपकी बातचीत होगी",
 	hideApplicationIcons = "एप्लिकेशन आइकन छुपाएं",
-	
 	categoryOverview = "अवलोकन",
+	
 	categoryApplications = "अनुप्रयोग",
 	categoryLibraries = "पुस्तकालयों",
 	categoryScripts = "स्क्रिप्ट",
 	categoryUpdates = "अपडेट",
 	categoryWallpapers = "वॉलपेपर",
-	
 	statisticsNewUser = "नए उपयोगकर्ता",
+	
 	statisticsMostPopularUser = "सर्वाधिक क्रियाशील",
 	statisticsUsersCount = "उपयोगकर्ता गिनती",
 	statisticsPublicationsCount = "प्रकाशन गिनती",
 	statisticsReviewsCount = "समीक्षा गिनती",
 	statisticsPopularPublication = "(लोकप्रिय प्रकाशन)",
 	statisticsMessagesCount = "संदेश गिनती",
-	
 	whatsNew = "नया क्या है",
+	
 	whatsNewInVersion = "संस्करण में नया क्या है",
 	areYouSure = "क्या आप वाकई प्रकाशन हटाना चाहते हैं?",
 	createShortcut = "डेस्कटॉप शॉर्टकट बनाएं",
@@ -54,8 +54,8 @@
 	relativePath = "तुलनात्मक पथ",
 	localizationDependency = "स्थानीयकरण फ़ाइल",
 	login = "लॉग इन करें",
-	
 	profile = "प्रोफ़ाइल",
+	
 	nickname = "उपनाम",
 	password = "पासवर्ड",
 	nicknameOrEmail = "ई-मेल या उपनाम",
@@ -75,8 +75,8 @@
 	createAccount = "खाता बनाएं",
 	registrationSuccessfull = "अपना खाता सत्यापित करने के लिए अपना ई-मेल और स्पैम फ़ोल्डर जांचें",
 	search = "खोज",
-	
 	byPopularity = "लोकप्रियता से",
+	
 	byRating = "रेटिंग के अनुसार",
 	byDate = "तिथि के अनुसार",
 	byName = "नाम से",
@@ -90,8 +90,8 @@
 	updateAll = "सब अद्यतित",
 	noUpdates = "आपके पास कोई अपडेट नहीं है",
 	changeReview = "समीक्षा बदलें",
-	
 	developer = "डेवलपर",
+	
 	version = "संस्करण",
 	license = "लाइसेंस",
 	category = "श्रेणी",
@@ -111,5 +111,6 @@
 	usersLoveReview = "उपयोगकर्ताओं को यह समीक्षा मददगार लगी",
 	thanksForVote = "आपकी राय के लिए धन्यवाद।",
 	uniqueDownloads = "अद्वितीय डाउनलोड",
-	previewDepencency = "छवि का पूर्वावलोकन करें"
+	previewDepencency = "छवि का पूर्वावलोकन करें",
+	hideApplicationPreviews = "एप्लिकेशन पूर्वावलोकन छुपाएं"
 }

--- a/Applications/App Market.app/Localizations/Italian.lang
+++ b/Applications/App Market.app/Localizations/Italian.lang
@@ -14,23 +14,23 @@
 	yourText = "Si:",
 	hereBeYourDialogs = "Ecco le vostre conversazioni",
 	hideApplicationIcons = "Nascondi le icone delle applicazioni",
-	
 	categoryOverview = "Panoramica",
+	
 	categoryApplications = "Applicazione",
 	categoryLibraries = "Biblioteca",
 	categoryScripts = "Script",
 	categoryUpdates = "Aggiornare",
 	categoryWallpapers = "Sfondi",
-	
 	statisticsNewUser = "Nuovo utente",
+	
 	statisticsMostPopularUser = "Più attivo",
 	statisticsUsersCount = "Gli utenti contano",
 	statisticsPublicationsCount = "Conta delle pubblicazioni",
 	statisticsReviewsCount = "Conta recensioni",
 	statisticsPopularPublication = "(pubblicazione popolare)",
 	statisticsMessagesCount = "Conta messaggi",
-	
 	whatsNew = "Cosa c'è di nuovo",
+	
 	whatsNewInVersion = "Cosa c'è di nuovo in versione",
 	areYouSure = "Eliminare veramente la pubblicazione?",
 	createShortcut = "Crea scorciatoia da scrivania",
@@ -54,8 +54,8 @@
 	relativePath = "Percorso relativo",
 	localizationDependency = "File di localizzazione",
 	login = "Login",
-	
 	profile = "Profilo",
+	
 	nickname = "Nomignolo",
 	password = "Parola d'ordine",
 	nicknameOrEmail = "E-Mail o soprannome",
@@ -75,8 +75,8 @@
 	createAccount = "Crea account",
 	registrationSuccessfull = "Controlla la tua cartella e-mail e spam per verificare il tuo account",
 	search = "Ricerca",
-	
 	byPopularity = "Di popolarità",
+	
 	byRating = "Per valutazione",
 	byDate = "Per data",
 	byName = "Per nome",
@@ -90,8 +90,8 @@
 	updateAll = "Aggiorna tutti",
 	noUpdates = "Non avete aggiornamenti",
 	changeReview = "Modifica revisione",
-	
 	developer = "Sviluppatore",
+	
 	version = "Versione",
 	license = "Licenza",
 	category = "Categoria",
@@ -111,5 +111,6 @@
 	usersLoveReview = "gli utenti hanno trovato utile questa recensione",
 	thanksForVote = "Grazie per la tua opinione.",
 	previewDepencency = "Anteprima dell'immagine",
-	uniqueDownloads = "Download unici"
+	uniqueDownloads = "Download unici",
+	hideApplicationPreviews = "Nascondi le anteprime delle applicazioni"
 }

--- a/Applications/App Market.app/Localizations/Japanese.lang
+++ b/Applications/App Market.app/Localizations/Japanese.lang
@@ -14,23 +14,23 @@
 	yourText = "君：",
 	hereBeYourDialogs = "これがあなたの会話になります",
 	hideApplicationIcons = "アプリケーションアイコンを非表示にする",
-	
 	categoryOverview = "概要",
+	
 	categoryApplications = "アプリケーション",
 	categoryLibraries = "ライブラリ",
 	categoryScripts = "スクリプト",
 	categoryUpdates = "更新",
 	categoryWallpapers = "壁紙",
-	
 	statisticsNewUser = "新しいユーザー",
+	
 	statisticsMostPopularUser = "最もアクティブ",
 	statisticsUsersCount = "ユーザー数",
 	statisticsPublicationsCount = "出版物は数えます",
 	statisticsReviewsCount = "レビュー数",
 	statisticsPopularPublication = "（人気出版物）",
 	statisticsMessagesCount = "メッセージ数",
-	
 	whatsNew = "新着情報",
+	
 	whatsNewInVersion = "バージョンの新機能",
 	areYouSure = "パブリケーションを削除してもよろしいですか？",
 	createShortcut = "デスクトップショートカットを作成します",
@@ -54,8 +54,8 @@
 	relativePath = "相対パス",
 	localizationDependency = "ローカリゼーションファイル",
 	login = "ログイン",
-	
 	profile = "プロフィール",
+	
 	nickname = "ニックネーム",
 	password = "パスワード",
 	nicknameOrEmail = "電子メールまたはニックネーム",
@@ -75,8 +75,8 @@
 	createAccount = "アカウントを作成する",
 	registrationSuccessfull = "あなたのアカウントを確認するためにあなたの電子メールとスパムフォルダをチェックしてください",
 	search = "探す",
-	
 	byPopularity = "人気で",
+	
 	byRating = "評価による",
 	byDate = "日付別",
 	byName = "名前で",
@@ -90,8 +90,8 @@
 	updateAll = "すべて更新",
 	noUpdates = "更新はありません",
 	changeReview = "レビューを変更",
-	
 	developer = "デベロッパー",
+	
 	version = "バージョン",
 	license = "ライセンス",
 	category = "カテゴリー",
@@ -111,5 +111,6 @@
 	usersLoveReview = "ユーザーはこのレビューが役に立ったと感じました",
 	thanksForVote = "ご意見ありがとうございます。",
 	previewDepencency = "プレビュー画像",
-	uniqueDownloads = "ユニークなダウンロード"
+	uniqueDownloads = "ユニークなダウンロード",
+	hideApplicationPreviews = "アプリケーションのプレビューを非表示にする"
 }

--- a/Applications/App Market.app/Localizations/Korean.lang
+++ b/Applications/App Market.app/Localizations/Korean.lang
@@ -14,23 +14,23 @@
 	yourText = "너:",
 	hereBeYourDialogs = "다음은 귀하의 대화 내용입니다.",
 	hideApplicationIcons = "애플리케이션 아이콘 숨기기",
-	
 	categoryOverview = "개요",
+	
 	categoryApplications = "애플리케이션",
 	categoryLibraries = "도서관",
 	categoryScripts = "스크립트",
 	categoryUpdates = "업데이트",
 	categoryWallpapers = "배경화면",
-	
 	statisticsNewUser = "새로운 사용자",
+	
 	statisticsMostPopularUser = "가장 활동적인",
 	statisticsUsersCount = "사용자 수",
 	statisticsPublicationsCount = "간행물 수",
 	statisticsReviewsCount = "리뷰 수",
 	statisticsPopularPublication = "(인기 간행물)",
 	statisticsMessagesCount = "메시지 수",
-	
 	whatsNew = "새로운 소식",
+	
 	whatsNewInVersion = "버전의 새로운 기능",
 	areYouSure = "출판물을 삭제하시겠습니까?",
 	createShortcut = "바탕 화면 바로 가기 만들기",
@@ -54,8 +54,8 @@
 	relativePath = "상대 경로",
 	localizationDependency = "현지화 파일",
 	login = "로그인",
-	
 	profile = "프로필",
+	
 	nickname = "별명",
 	password = "비밀번호",
 	nicknameOrEmail = "이메일 또는 닉네임",
@@ -75,8 +75,8 @@
 	createAccount = "계정 만들기",
 	registrationSuccessfull = "이메일 및 스팸 폴더를 확인하여 계정 확인",
 	search = "검색",
-	
 	byPopularity = "인기순으로",
+	
 	byRating = "등급별",
 	byDate = "날짜별",
 	byName = "이름으로",
@@ -90,8 +90,8 @@
 	updateAll = "모두 업데이트",
 	noUpdates = "업데이트가 없습니다.",
 	changeReview = "리뷰 변경",
-	
 	developer = "개발자",
+	
 	version = "버전",
 	license = "특허",
 	category = "범주",
@@ -111,5 +111,6 @@
 	usersLoveReview = "사용자가 이 리뷰가 도움이 되었다고 생각함",
 	thanksForVote = "의견 감사합니다.",
 	uniqueDownloads = "고유 다운로드",
-	previewDepencency = "미리보기 이미지"
+	previewDepencency = "미리보기 이미지",
+	hideApplicationPreviews = "애플리케이션 미리보기 숨기기"
 }

--- a/Applications/App Market.app/Localizations/Polish.lang
+++ b/Applications/App Market.app/Localizations/Polish.lang
@@ -14,23 +14,23 @@
 	yourText = "Ty:",
 	hereBeYourDialogs = "Tu będą twoje rozmowy",
 	hideApplicationIcons = "Ukryj ikony aplikacji",
-	
 	categoryOverview = "Przegląd",
+	
 	categoryApplications = "Aplikacje",
 	categoryLibraries = "Biblioteki",
 	categoryScripts = "Skrypty",
 	categoryUpdates = "Aktualizacje",
 	categoryWallpapers = "Tapety",
-	
 	statisticsNewUser = "Nowy użytkownik",
+	
 	statisticsMostPopularUser = "Najbardziej aktywny",
 	statisticsUsersCount = "Liczba użytkowników",
 	statisticsPublicationsCount = "Liczba publikacji",
 	statisticsReviewsCount = "Liczba recenzji",
 	statisticsPopularPublication = "(popularna publikacja)",
 	statisticsMessagesCount = "Liczba wiadomości",
-	
 	whatsNew = "Co nowego",
+	
 	whatsNewInVersion = "Co nowego w wersji",
 	areYouSure = "Czy na pewno chcesz usunąć publikację?",
 	createShortcut = "Utwórz skrót na pulpicie",
@@ -54,8 +54,8 @@
 	relativePath = "Względna ścieżka dostępu",
 	localizationDependency = "Plik lokalizacyjny",
 	login = "Zaloguj sie",
-	
 	profile = "Profil",
+	
 	nickname = "Przezwisko",
 	password = "Hasło",
 	nicknameOrEmail = "E-mail lub pseudonim",
@@ -75,8 +75,8 @@
 	createAccount = "Utwórz konto",
 	registrationSuccessfull = "Sprawdź swoją pocztę e-mail i folder ze spamem, aby zweryfikować swoje konto",
 	search = "Szukaj",
-	
 	byPopularity = "Według popularności",
+	
 	byRating = "Według oceny",
 	byDate = "Według daty",
 	byName = "Wg nazwy",
@@ -90,8 +90,8 @@
 	updateAll = "Zaktualizuj wszystko",
 	noUpdates = "Nie masz żadnych aktualizacji",
 	changeReview = "Zmień recenzję",
-	
 	developer = "Deweloper",
+	
 	version = "Wersja",
 	license = "Licencja",
 	category = "Kategoria",
@@ -111,5 +111,6 @@
 	usersLoveReview = "użytkownicy uznali tę opinię za pomocną",
 	thanksForVote = "Dziękuję za Twoją opinię.",
 	uniqueDownloads = "Unikalne pliki do pobrania",
-	previewDepencency = "Podgląd obrazu"
+	previewDepencency = "Podgląd obrazu",
+	hideApplicationPreviews = "Ukryj podglądy aplikacji"
 }

--- a/Applications/App Market.app/Localizations/Portuguese.lang
+++ b/Applications/App Market.app/Localizations/Portuguese.lang
@@ -14,23 +14,23 @@
 	yourText = "Vocês:",
 	hereBeYourDialogs = "Aqui estarão suas conversas",
 	hideApplicationIcons = "Ocultar ícones de aplicativos",
-	
 	categoryOverview = "Visão geral",
+	
 	categoryApplications = "Formulários",
 	categoryLibraries = "Bibliotecas",
 	categoryScripts = "Roteiros",
 	categoryUpdates = "Atualizações",
 	categoryWallpapers = "Papeis de parede",
-	
 	statisticsNewUser = "Novo usuário",
+	
 	statisticsMostPopularUser = "Mais ativo",
 	statisticsUsersCount = "Contagem de usuários",
 	statisticsPublicationsCount = "Contagem de publicações",
 	statisticsReviewsCount = "Contagem de avaliações",
 	statisticsPopularPublication = "(publicação popular)",
 	statisticsMessagesCount = "Contagem de mensagens",
-	
 	whatsNew = "O que há de novo",
+	
 	whatsNewInVersion = "O que há de novo na versão",
 	areYouSure = "Tem certeza de que deseja excluir a publicação?",
 	createShortcut = "Criar atalho na área de trabalho",
@@ -54,8 +54,8 @@
 	relativePath = "Caminho relativo",
 	localizationDependency = "Arquivo de localização",
 	login = "Conecte-se",
-	
 	profile = "Perfil",
+	
 	nickname = "Apelido",
 	password = "Senha",
 	nicknameOrEmail = "E-mail ou apelido",
@@ -75,8 +75,8 @@
 	createAccount = "Criar Conta",
 	registrationSuccessfull = "Verifique sua pasta de e-mail e spam para verificar sua conta",
 	search = "Procurar",
-	
 	byPopularity = "Por popularidade",
+	
 	byRating = "Por classificação",
 	byDate = "Por data",
 	byName = "Por nome",
@@ -90,8 +90,8 @@
 	updateAll = "Atualize tudo",
 	noUpdates = "Você não tem atualizações",
 	changeReview = "Alterar revisão",
-	
 	developer = "Desenvolvedor",
+	
 	version = "Versão",
 	license = "Licença",
 	category = "Categoria",
@@ -111,5 +111,6 @@
 	usersLoveReview = "os usuários acharam esta análise útil",
 	thanksForVote = "Obrigado pela sua opinião.",
 	previewDepencency = "Visualizar imagem",
-	uniqueDownloads = "Downloads exclusivos"
+	uniqueDownloads = "Downloads exclusivos",
+	hideApplicationPreviews = "Ocultar visualizações de aplicativos"
 }

--- a/Applications/App Market.app/Localizations/Slovak.lang
+++ b/Applications/App Market.app/Localizations/Slovak.lang
@@ -14,23 +14,23 @@
 	yourText = "ty:",
 	hereBeYourDialogs = "Tu budú vaše rozhovory",
 	hideApplicationIcons = "Skryť ikony aplikácií",
-	
 	categoryOverview = "Prehľad",
+	
 	categoryApplications = "Aplikácie",
 	categoryLibraries = "Knižnice",
 	categoryScripts = "Skriptá",
 	categoryUpdates = "Aktualizácie",
 	categoryWallpapers = "Tapety",
-	
 	statisticsNewUser = "Nový užívateľ",
+	
 	statisticsMostPopularUser = "Najaktívnejší",
 	statisticsUsersCount = "Používatelia sa počítajú",
 	statisticsPublicationsCount = "Publikácie sa počítajú",
 	statisticsReviewsCount = "Recenzie sa počítajú",
 	statisticsPopularPublication = "(populárna publikácia)",
 	statisticsMessagesCount = "Počet správ",
-	
 	whatsNew = "Čo je nové",
+	
 	whatsNewInVersion = "Čo je nové vo verzii",
 	areYouSure = "Naozaj chcete odstrániť publikáciu?",
 	createShortcut = "Vytvoriť zástupcu na ploche",
@@ -54,8 +54,8 @@
 	relativePath = "Relatívna cesta",
 	localizationDependency = "Lokalizačný súbor",
 	login = "Prihlásiť sa",
-	
 	profile = "Profil",
+	
 	nickname = "prezývka",
 	password = "heslo",
 	nicknameOrEmail = "E-mail alebo prezývka",
@@ -75,8 +75,8 @@
 	createAccount = "Vytvoriť účet",
 	registrationSuccessfull = "Skontrolujte svoj e-mail a priečinok so spamom a overte svoj účet",
 	search = "Vyhľadávanie",
-	
 	byPopularity = "Podľa popularity",
+	
 	byRating = "Podľa hodnotenia",
 	byDate = "Podľa dátumu",
 	byName = "Podľa názvu",
@@ -90,8 +90,8 @@
 	updateAll = "Aktualizovať všetko",
 	noUpdates = "Nemáte žiadne aktualizácie",
 	changeReview = "Zmeniť recenziu",
-	
 	developer = "Vývojár",
+	
 	version = "Verzia",
 	license = "Licencia",
 	category = "Kategória",
@@ -111,5 +111,6 @@
 	usersLoveReview = "používatelia považovali túto recenziu za užitočnú",
 	thanksForVote = "dakujem za nazor.",
 	previewDepencency = "Ukážkový obrázok",
-	uniqueDownloads = "Jedinečné sťahovanie"
+	uniqueDownloads = "Jedinečné sťahovanie",
+	hideApplicationPreviews = "Skryť ukážky aplikácií"
 }

--- a/Applications/App Market.app/Localizations/Spanish.lang
+++ b/Applications/App Market.app/Localizations/Spanish.lang
@@ -14,23 +14,23 @@
 	yourText = "Tu:",
 	hereBeYourDialogs = "Aqui estaran tus conversaciones",
 	hideApplicationIcons = "Ocultar iconos de aplicaciones",
-	
 	categoryOverview = "Vision General",
+	
 	categoryApplications = "Aplicaciones",
 	categoryLibraries = "Librerias",
 	categoryScripts = "Guiones",
 	categoryUpdates = "Actualizaciones",
 	categoryWallpapers = "Fondos de pantalla",
-	
 	statisticsNewUser = "Nuevo usuario",
+	
 	statisticsMostPopularUser = "Mas Activo",
 	statisticsUsersCount = "Recuento de usuarios",
 	statisticsPublicationsCount = "Recuento de publicaciones",
 	statisticsReviewsCount = "Recuento de valoraciones",
 	statisticsPopularPublication = "(publicacion popular)",
 	statisticsMessagesCount = "Recuento de mensajes",
-	
 	whatsNew = "Que hay nuevo",
+	
 	whatsNewInVersion = "Que hay nuevo en la version",
 	areYouSure = "Estas seguro que quieres eliminar la publicacion?",
 	createShortcut = "Crear Acceso Directo en el Escritorio",
@@ -54,8 +54,8 @@
 	relativePath = "Ruta Relativa",
 	localizationDependency = "Archivo de localizacion",
 	login = "Iniciar sesion",
-	
 	profile = "Perfil",
+	
 	nickname = "Apodo",
 	password = "Contraseña",
 	nicknameOrEmail = "Email o apodo",
@@ -75,8 +75,8 @@
 	createAccount = "Crear Cuenta",
 	registrationSuccessfull = "Checkea tu email y carpeta de spam para verificar tu cuenta",
 	search = "Buscar",
-	
 	byPopularity = "Por Popularidad",
+	
 	byRating = "Por Clasificacion",
 	byDate = "Por Fecha",
 	byName = "Por Nombre",
@@ -90,8 +90,8 @@
 	updateAll = "Actualizar Todo",
 	noUpdates = "No tienes actualizaciones",
 	changeReview = "Cambiar valoracion",
-	
 	developer = "Desarrollador",
+	
 	version = "Versión",
 	license = "Licencia",
 	category = "Categoria",
@@ -111,5 +111,6 @@
 	usersLoveReview = "Usuarios encontraron esta valoracion util",
 	thanksForVote = "Gracias por tu opinion.",
 	uniqueDownloads = "Descargas únicas",
-	previewDepencency = "Imagen previa"
+	previewDepencency = "Imagen previa",
+	hideApplicationPreviews = "Ocultar vistas previas de aplicaciones"
 }

--- a/Applications/App Market.app/Localizations/Ukrainian.lang
+++ b/Applications/App Market.app/Localizations/Ukrainian.lang
@@ -14,23 +14,23 @@
 	yourText = "Ви:",
 	hereBeYourDialogs = "Тут будуть відображені ваші діалоги",
 	hideApplicationIcons = "Приховати значки програм",
-	
 	categoryOverview = "Головна",
+	
 	categoryApplications = "Додатки",
 	categoryLibraries = "Бібліотеки",
 	categoryScripts = "Скрипти",
 	categoryUpdates = "Оновлення",
 	categoryWallpapers = "Шпалери",
-	
 	statisticsNewUser = "Новий користувач",
+	
 	statisticsMostPopularUser = "Найбільш активний",
 	statisticsUsersCount = "Число користувачів",
 	statisticsPublicationsCount = "Число публікацій",
 	statisticsReviewsCount = "Число відгуків",
 	statisticsPopularPublication = "(Популярна публікація)",
 	statisticsMessagesCount = "Число повідомлень",
-	
 	whatsNew = "Що нового",
+	
 	whatsNewInVersion = "Що нового у версії",
 	areYouSure = "Ви впевнені, що хочете видалити публікацію?",
 	createShortcut = "Створити ярлик на робочому столі",
@@ -54,8 +54,8 @@
 	relativePath = "Відносний шлях",
 	localizationDependency = "Файл локалізації",
 	login = "Авторизація",
-	
 	profile = "Профіль",
+	
 	nickname = "Нікнейм",
 	password = "Пароль",
 	nicknameOrEmail = "Нікнейм або ел. скринька",
@@ -75,8 +75,8 @@
 	createAccount = "Створити акаунт",
 	registrationSuccessfull = "Перевірте свою пошту (і папку спаму), щоб підтвердити аккаунт",
 	search = "Пошук",
-	
 	byPopularity = "За популярністю",
+	
 	byRating = "За рейтингом",
 	byDate = "По даті",
 	byName = "По імені",
@@ -90,8 +90,8 @@
 	updateAll = "Оновити все",
 	noUpdates = "У вас найновіше ПЗ",
 	changeReview = "Змінити відгук",
-	
 	developer = "Розробник",
+	
 	version = "Версія",
 	license = "Ліцензія",
 	category = "Категорія",
@@ -111,5 +111,6 @@
 	usersLoveReview = "користувачів вважають цей відгук корисним",
 	thanksForVote = "Дякую за вашу думку",
 	previewDepencency = "Попередній перегляд зображення",
-	uniqueDownloads = "Унікальні завантаження"
+	uniqueDownloads = "Унікальні завантаження",
+	hideApplicationPreviews = "Приховати попередній перегляд програми"
 }

--- a/Applications/VK.app/Localizations/Spanish.lang
+++ b/Applications/VK.app/Localizations/Spanish.lang
@@ -27,7 +27,6 @@
 	userIsYourFriend = "Es tu amigo",
 	profileCounters = {
 		{
-			
 			field = "seguidores",
 			description = " seguidores"
 		},


### PR DESCRIPTION
Because I was working with an old copy of the localization data, my previous pull request missed addding the new `hideApplicationPreviews` key, and this pull request is fixing that.