### PR TITLE
Blank password bugfix!

### DIFF
--- a/Installer/Main.lua
+++ b/Installer/Main.lua
@@ -352,7 +352,7 @@ end
 local function checkUserInputs()
 	local nameEmpty = #usernameInput.text == 0
 	local nameVaild = usernameInput.text:match("^%w[%w%s_]+$")
-	local passValid = withoutPasswordSwitchAndLabel.switch.state or #passwordInput.text == 0 or #passwordSubmitInput.text == 0 or passwordInput.text == passwordSubmitInput.text
+	local passValid = withoutPasswordSwitchAndLabel.switch.state or (#passwordInput.text > 0 and #passwordSubmitInput.text > 0 and passwordInput.text == passwordSubmitInput.text)
 
 	if (nameEmpty or nameVaild) and passValid then
 		usernamePasswordText.hidden = true


### PR DESCRIPTION
If the user set a blank password without checking "don't use passwords", it will result in a softlock. 
The login screen will ask the user for password but it won't allow any blank passwords. 
However, users CAN set a blank password in MineOS setup without enabling "don't use passwords". 
This pull request fixes this stupid mistake by simply not allowing any blank passwords unless "don't use passwords" is enabled. 