### PR TITLE
Re-enabled the next button for File system Selection stage.

### DIFF
--- a/Installer/Main.lua
+++ b/Installer/Main.lua
@@ -418,7 +418,7 @@ end)
 -- Filesystem selection stage
 addStage(function()
 	prevButton.disabled = false
-	nextButton.disabled = true
+	nextButton.disabled = false
 
 	layout:addChild(GUI.object(1, 1, 1, 1))
 	addTitle(0x696969, localization.select)


### PR DESCRIPTION
Set "nextButton.disabled" in the File system selection stage to false.
Since it was impossible to get past the Filesystem/Disk selection screen due to the next/continue button being disabled.